### PR TITLE
feat: capture TLS handshake timing and forward as headers

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -2,6 +2,7 @@ package caddy_clienthello
 
 import (
 	"sync"
+	"time"
 
 	"github.com/caddyserver/caddy/v2"
 	"go.uber.org/zap"
@@ -19,14 +20,25 @@ type CacheEntry struct {
 	Value string
 }
 
+// TimingEntry records the two moments needed to compute the per-connection
+// handshake-timing deltas that mirror Bumblebee's tcp_to_chello_ms and
+// chello_to_handshake_ms. Keyed by remote addr (unique per TCP connection)
+// so ServeHTTP can look them up on the first request.
+type TimingEntry struct {
+	ConnectionStart     time.Time // when listener.Accept() returned
+	ClientHelloReceived time.Time // when the CH bytes were fully peeked
+}
+
 type Cache struct {
 	clientHellos map[string]CacheEntry
+	timings      map[string]TimingEntry
 	lock         sync.RWMutex
 	logger *zap.Logger
 }
 
 func (c *Cache) Provision(ctx caddy.Context) error {
 	c.clientHellos = make(map[string]CacheEntry)
+	c.timings = make(map[string]TimingEntry)
 	c.logger = ctx.Logger(c)
 	return nil
 }
@@ -48,7 +60,35 @@ func (c *Cache) ClearClientHello(addr string) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	delete(c.clientHellos, addr)
+	delete(c.timings, addr)
 	c.logger.Info("cache size", zap.Int("size", len(c.clientHellos)))
+}
+
+// SetTiming records the (connection_start, client_hello_received) pair
+// for a connection, keyed by remote addr so ServeHTTP can look them up
+// on the first request over that TCP connection.
+func (c *Cache) SetTiming(addr string, start time.Time, chelloReceived time.Time) {
+	c.logger.Debug("SetTiming", zap.String("addr", addr))
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.timings[addr] = TimingEntry{
+		ConnectionStart:     start,
+		ClientHelloReceived: chelloReceived,
+	}
+}
+
+// GetTiming returns the timing entry for a connection, or nil if none
+// is cached (e.g. connection wasn't a TLS handshake, or was already
+// cleared on close).
+func (c *Cache) GetTiming(addr string) *TimingEntry {
+	c.logger.Debug("GetTiming", zap.String("addr", addr))
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	entry, found := c.timings[addr]
+	if !found {
+		return nil
+	}
+	return &entry
 }
 
 func (c *Cache) GetClientHello(addr string) *string {

--- a/clientHelloConnWrapper.go
+++ b/clientHelloConnWrapper.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/base64"
 	"net"
+	"time"
 
 	"go.uber.org/zap"
 )
@@ -16,10 +17,11 @@ type ClientHelloConnWrapper struct {
 	bufferedReader *bufio.Reader
 	done   bool
 	cache *Cache
+	connectionStart time.Time // when listener.Accept() returned — plumbed in so Read can compute tcp_to_chello_ms
 }
 
 // NewClientHelloConnWrapper creates a new wrapper
-func NewClientHelloConnWrapper(conn net.Conn, cache *Cache, log *zap.Logger) *ClientHelloConnWrapper {
+func NewClientHelloConnWrapper(conn net.Conn, cache *Cache, log *zap.Logger, connectionStart time.Time) *ClientHelloConnWrapper {
 	// create a buffered reader for the conn
 	bufferedReader := bufio.NewReaderSize(conn, 65536) // 64KB buffer, the max size of a TLS record
 	return &ClientHelloConnWrapper{
@@ -28,6 +30,7 @@ func NewClientHelloConnWrapper(conn net.Conn, cache *Cache, log *zap.Logger) *Cl
 		bufferedReader: bufferedReader,
 		done:   false, // we haven't read the client hello yet
 		cache: cache,
+		connectionStart: connectionStart,
 	}
 }
 
@@ -81,9 +84,18 @@ func (r *ClientHelloConnWrapper) Read(b []byte) (n int, err error) {
 
 	// convert the client hello bytes to base64
 	encoded := base64.StdEncoding.EncodeToString(bytes)
-	
+
+	// t1: full CH bytes have been peeked. Delta from t0 (connectionStart)
+	// is inflated by the entire client-to-exit RTT chain when a CONNECT
+	// proxy sits in the path, because CH bytes only reach the exit
+	// box's TCP stack after traversing every hop. Same signal Bumblebee
+	// captures via ConnectionMetadata.tcp_to_chello_ms.
+	clientHelloReceived := time.Now()
+
 	// record client hello in cache
-	r.cache.SetClientHello(r.Conn.RemoteAddr().String(), encoded)
+	addr := r.Conn.RemoteAddr().String()
+	r.cache.SetClientHello(addr, encoded)
+	r.cache.SetTiming(addr, r.connectionStart, clientHelloReceived)
 
 	// delegate the original read call to the buffered reader
 	return r.bufferedReader.Read(b)

--- a/handler.go
+++ b/handler.go
@@ -2,6 +2,8 @@ package caddy_clienthello
 
 import (
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -65,6 +67,37 @@ func (h *ClientHelloHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request
 		} else {
 			h.log.Debug("Adding encoded ClientHello to request", zap.String("addr", req.RemoteAddr), zap.String("client_hello", *clientHello))
 			req.Header.Add("X-TLS-ClientHello", *clientHello)
+		}
+
+		// Per-connection handshake timing — mirrors Bumblebee's
+		// tcp_to_chello_ms and chello_to_handshake_ms fields on
+		// ConnectionMetadata / SessionHeaders. Forwarded as headers so
+		// pronodes can log them for proxy-detection distribution
+		// analysis. Constant across every request over the same TCP
+		// connection; downstream should dedupe by (jti, values) if that
+		// matters.
+		//
+		// Caveat vs Bumblebee: chello_to_handshake_ms here is measured
+		// at ServeHTTP entry, which is a few ms after the TLS
+		// handshake actually completes (the std lib finishes the
+		// handshake between the CH being peeked and Caddy invoking
+		// this middleware). Same signal shape as Bumblebee's rustls
+		// into_stream().await measurement; slight positive baseline
+		// offset — downstream should not compare absolute values to
+		// Bumblebee's without accounting for that.
+		timing := h.cache.GetTiming(req.RemoteAddr)
+		if timing != nil {
+			serveEntry := time.Now()
+			tcpToChelloMs := timing.ClientHelloReceived.Sub(timing.ConnectionStart).Milliseconds()
+			chelloToHandshakeMs := serveEntry.Sub(timing.ClientHelloReceived).Milliseconds()
+			req.Header.Add("X-TLS-TCP-To-Chello-Ms", strconv.FormatInt(tcpToChelloMs, 10))
+			req.Header.Add("X-TLS-Chello-To-Handshake-Ms", strconv.FormatInt(chelloToHandshakeMs, 10))
+			h.log.Debug(
+				"Added handshake timing headers",
+				zap.String("addr", req.RemoteAddr),
+				zap.Int64("tcp_to_chello_ms", tcpToChelloMs),
+				zap.Int64("chello_to_handshake_ms", chelloToHandshakeMs),
+			)
 		}
 	}
 

--- a/listener.go
+++ b/listener.go
@@ -2,6 +2,7 @@ package caddy_clienthello
 
 import (
 	"net"
+	"time"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -79,8 +80,14 @@ func (l *clientHelloListener) Accept() (net.Conn, error) {
 		return nil, err
 	}
 
+	// t0: the moment we returned from the underlying TCP Accept.
+	// Mirrors Bumblebee's ConnectionMetadata.connection_start. Plumbed
+	// into the wrapper so ClientHelloConnWrapper.Read can compute
+	// tcp_to_chello_ms once the CH has been peeked.
+	connectionStart := time.Now()
+
 	// wrap the conn in a ClientHelloConnWrapper to intercept the client hello
-	conn = NewClientHelloConnWrapper(conn, l.cache, l.log)
+	conn = NewClientHelloConnWrapper(conn, l.cache, l.log, connectionStart)
 
 	return conn, nil
 }


### PR DESCRIPTION
## Summary

Adds two per-connection deltas measured across the same TLS lifecycle events the Rust listener already measures, so pronodes can log them with the same semantics regardless of which ingress accepted the connection.

- \`X-TLS-TCP-To-Chello-Ms\` — time from \`listener.Accept()\` return to full CH peek. Inflated by the entire client-to-exit RTT chain when a CONNECT proxy sits in the path (browser → local relay → upstream proxy → exit → Caddy).
- \`X-TLS-Chello-To-Handshake-Ms\` — time from CH peek to ServeHTTP entry. 
## What changed

- \`cache.go\` — new \`TimingEntry\` + \`timings\` map on \`Cache\`, \`SetTiming\` and \`GetTiming\` helpers, timing entries also cleared by \`ClearClientHello\` on connection close.
- \`listener.go\` — capture \`time.Now()\` immediately after \`Accept()\` returns, plumb into the new wrapper constructor arg.
- \`clientHelloConnWrapper.go\` — capture \`time.Now()\` after the full CH is peeked; store both timestamps in the cache keyed by remote addr.
- \`handler.go\` — on ServeHTTP, look up the timing pair, compute both deltas, add the two headers before delegating.

## Test plan

- [ ] Build \`captcha\` Caddy image with this branch pinned via xcaddy: \`xcaddy build --with github.com/prosopo/chaddy@handshake-timing\`
- [ ] Deploy to a pronode staging host
- [ ] curl direct to the pronode HTTPS endpoint; confirm \`X-TLS-TCP-To-Chello-Ms\` and \`X-TLS-Chello-To-Handshake-Ms\` are present on the request the app receives (~0-50 ms)
- [ ] curl via \`proxychains4\` (the SOCKS5 proxy config recently landed in \`~/.proxychains/proxychains.conf\`); confirm both values elevate together
- [ ] Verify HTTP/3 requests do not receive the headers (existing chaddy behaviour for CH capture)
- [ ] Verify \`go build\` clean (already checked locally)
- [ ] Verify \`go vet\` doesn't add new warnings beyond the pre-existing \`Cache passes lock by value\` finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)