### PR TITLE
feat: emit handshake timing in microseconds, not milliseconds

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -21,8 +21,8 @@ type CacheEntry struct {
 }
 
 // TimingEntry records the two moments needed to compute the per-connection
-// handshake-timing deltas that mirror Bumblebee's tcp_to_chello_ms and
-// chello_to_handshake_ms. Keyed by remote addr (unique per TCP connection)
+// handshake-timing deltas that mirror Bumblebee's tcp_to_chello_us and
+// chello_to_handshake_us. Keyed by remote addr (unique per TCP connection)
 // so ServeHTTP can look them up on the first request.
 type TimingEntry struct {
 	ConnectionStart     time.Time // when listener.Accept() returned

--- a/cache.go
+++ b/cache.go
@@ -21,9 +21,9 @@ type CacheEntry struct {
 }
 
 // TimingEntry records the two moments needed to compute the per-connection
-// handshake-timing deltas that mirror Bumblebee's tcp_to_chello_us and
-// chello_to_handshake_us. Keyed by remote addr (unique per TCP connection)
-// so ServeHTTP can look them up on the first request.
+// tcp_to_chello_us and chello_to_handshake_us deltas. Keyed by remote addr
+// (unique per TCP connection) so ServeHTTP can look them up on the first
+// request.
 type TimingEntry struct {
 	ConnectionStart     time.Time // when listener.Accept() returned
 	ClientHelloReceived time.Time // when the CH bytes were fully peeked

--- a/clientHelloConnWrapper.go
+++ b/clientHelloConnWrapper.go
@@ -17,7 +17,7 @@ type ClientHelloConnWrapper struct {
 	bufferedReader *bufio.Reader
 	done   bool
 	cache *Cache
-	connectionStart time.Time // when listener.Accept() returned — plumbed in so Read can compute tcp_to_chello_ms
+	connectionStart time.Time // when listener.Accept() returned — plumbed in so Read can compute tcp_to_chello_us
 }
 
 // NewClientHelloConnWrapper creates a new wrapper
@@ -89,7 +89,7 @@ func (r *ClientHelloConnWrapper) Read(b []byte) (n int, err error) {
 	// is inflated by the entire client-to-exit RTT chain when a CONNECT
 	// proxy sits in the path, because CH bytes only reach the exit
 	// box's TCP stack after traversing every hop. Same signal Bumblebee
-	// captures via ConnectionMetadata.tcp_to_chello_ms.
+	// captures via ConnectionMetadata.tcp_to_chello_us.
 	clientHelloReceived := time.Now()
 
 	// record client hello in cache

--- a/clientHelloConnWrapper.go
+++ b/clientHelloConnWrapper.go
@@ -88,8 +88,7 @@ func (r *ClientHelloConnWrapper) Read(b []byte) (n int, err error) {
 	// t1: full CH bytes have been peeked. Delta from t0 (connectionStart)
 	// is inflated by the entire client-to-exit RTT chain when a CONNECT
 	// proxy sits in the path, because CH bytes only reach the exit
-	// box's TCP stack after traversing every hop. Same signal Bumblebee
-	// captures via ConnectionMetadata.tcp_to_chello_us.
+	// box's TCP stack after traversing every hop.
 	clientHelloReceived := time.Now()
 
 	// record client hello in cache

--- a/handler.go
+++ b/handler.go
@@ -70,33 +70,39 @@ func (h *ClientHelloHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request
 		}
 
 		// Per-connection handshake timing — mirrors Bumblebee's
-		// tcp_to_chello_ms and chello_to_handshake_ms fields on
+		// tcp_to_chello and chello_to_handshake fields on
 		// ConnectionMetadata / SessionHeaders. Forwarded as headers so
 		// pronodes can log them for proxy-detection distribution
 		// analysis. Constant across every request over the same TCP
 		// connection; downstream should dedupe by (jti, values) if that
 		// matters.
 		//
-		// Caveat vs Bumblebee: chello_to_handshake_ms here is measured
-		// at ServeHTTP entry, which is a few ms after the TLS
-		// handshake actually completes (the std lib finishes the
-		// handshake between the CH being peeked and Caddy invoking
-		// this middleware). Same signal shape as Bumblebee's rustls
-		// into_stream().await measurement; slight positive baseline
-		// offset — downstream should not compare absolute values to
-		// Bumblebee's without accounting for that.
+		// Microseconds, not milliseconds: ms buckets fast handshakes
+		// (local proxies, same-DC clients) to 0/1 and destroys the
+		// distribution shape we need for detection. Go's monotonic
+		// clock via time.Now() is ~1μs precise on Linux vDSO — μs is
+		// the honest resolution ceiling.
+		//
+		// Caveat vs Bumblebee: chello_to_handshake_us here is measured
+		// at ServeHTTP entry, which is a few tens of μs to a few ms
+		// after the TLS handshake actually completes (the std lib
+		// finishes the handshake between the CH being peeked and
+		// Caddy invoking this middleware). Same signal shape as
+		// Bumblebee's rustls into_stream().await measurement; slight
+		// positive baseline offset — downstream should not compare
+		// absolute values to Bumblebee's without accounting for that.
 		timing := h.cache.GetTiming(req.RemoteAddr)
 		if timing != nil {
 			serveEntry := time.Now()
-			tcpToChelloMs := timing.ClientHelloReceived.Sub(timing.ConnectionStart).Milliseconds()
-			chelloToHandshakeMs := serveEntry.Sub(timing.ClientHelloReceived).Milliseconds()
-			req.Header.Add("X-TLS-TCP-To-Chello-Ms", strconv.FormatInt(tcpToChelloMs, 10))
-			req.Header.Add("X-TLS-Chello-To-Handshake-Ms", strconv.FormatInt(chelloToHandshakeMs, 10))
+			tcpToChelloUs := timing.ClientHelloReceived.Sub(timing.ConnectionStart).Microseconds()
+			chelloToHandshakeUs := serveEntry.Sub(timing.ClientHelloReceived).Microseconds()
+			req.Header.Add("X-TLS-TCP-To-Chello-Us", strconv.FormatInt(tcpToChelloUs, 10))
+			req.Header.Add("X-TLS-Chello-To-Handshake-Us", strconv.FormatInt(chelloToHandshakeUs, 10))
 			h.log.Debug(
 				"Added handshake timing headers",
 				zap.String("addr", req.RemoteAddr),
-				zap.Int64("tcp_to_chello_ms", tcpToChelloMs),
-				zap.Int64("chello_to_handshake_ms", chelloToHandshakeMs),
+				zap.Int64("tcp_to_chello_us", tcpToChelloUs),
+				zap.Int64("chello_to_handshake_us", chelloToHandshakeUs),
 			)
 		}
 	}

--- a/handler.go
+++ b/handler.go
@@ -69,28 +69,24 @@ func (h *ClientHelloHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request
 			req.Header.Add("X-TLS-ClientHello", *clientHello)
 		}
 
-		// Per-connection handshake timing — mirrors Bumblebee's
-		// tcp_to_chello and chello_to_handshake fields on
-		// ConnectionMetadata / SessionHeaders. Forwarded as headers so
-		// pronodes can log them for proxy-detection distribution
-		// analysis. Constant across every request over the same TCP
-		// connection; downstream should dedupe by (jti, values) if that
-		// matters.
+		// Per-connection TLS handshake timing, forwarded as headers so
+		// the downstream service can log them for proxy-detection
+		// distribution analysis. Constant across every request over
+		// the same TCP connection; the downstream should dedupe by
+		// (connection-id, values) if that matters.
 		//
 		// Microseconds, not milliseconds: ms buckets fast handshakes
 		// (local proxies, same-DC clients) to 0/1 and destroys the
-		// distribution shape we need for detection. Go's monotonic
+		// distribution shape needed for detection. Go's monotonic
 		// clock via time.Now() is ~1μs precise on Linux vDSO — μs is
 		// the honest resolution ceiling.
 		//
-		// Caveat vs Bumblebee: chello_to_handshake_us here is measured
-		// at ServeHTTP entry, which is a few tens of μs to a few ms
-		// after the TLS handshake actually completes (the std lib
-		// finishes the handshake between the CH being peeked and
-		// Caddy invoking this middleware). Same signal shape as
-		// Bumblebee's rustls into_stream().await measurement; slight
-		// positive baseline offset — downstream should not compare
-		// absolute values to Bumblebee's without accounting for that.
+		// chello_to_handshake_us is measured at ServeHTTP entry, which
+		// is a few tens of μs to a few ms after the TLS handshake
+		// actually completes (the std lib finishes the handshake
+		// between the CH being peeked and Caddy invoking this
+		// middleware). Small positive baseline offset — treat the
+		// value as relative-within-a-fleet, not absolute.
 		timing := h.cache.GetTiming(req.RemoteAddr)
 		if timing != nil {
 			serveEntry := time.Now()

--- a/listener.go
+++ b/listener.go
@@ -83,7 +83,7 @@ func (l *clientHelloListener) Accept() (net.Conn, error) {
 	// t0: the moment we returned from the underlying TCP Accept.
 	// Mirrors Bumblebee's ConnectionMetadata.connection_start. Plumbed
 	// into the wrapper so ClientHelloConnWrapper.Read can compute
-	// tcp_to_chello_ms once the CH has been peeked.
+	// tcp_to_chello_us once the CH has been peeked.
 	connectionStart := time.Now()
 
 	// wrap the conn in a ClientHelloConnWrapper to intercept the client hello

--- a/listener.go
+++ b/listener.go
@@ -81,9 +81,8 @@ func (l *clientHelloListener) Accept() (net.Conn, error) {
 	}
 
 	// t0: the moment we returned from the underlying TCP Accept.
-	// Mirrors Bumblebee's ConnectionMetadata.connection_start. Plumbed
-	// into the wrapper so ClientHelloConnWrapper.Read can compute
-	// tcp_to_chello_us once the CH has been peeked.
+	// Plumbed into the wrapper so ClientHelloConnWrapper.Read can
+	// compute tcp_to_chello_us once the CH has been peeked.
 	connectionStart := time.Now()
 
 	// wrap the conn in a ClientHelloConnWrapper to intercept the client hello


### PR DESCRIPTION
## Summary
- Rename \`X-TLS-TCP-To-Chello-Ms\` / \`X-TLS-Chello-To-Handshake-Ms\` to \`-Us\` variants, switch \`.Milliseconds()\` → \`.Microseconds()\`.
- Milliseconds bucket fast handshakes (local proxies, same-DC clients) to \`0\`/\`1\` and destroy the distribution shape we need for proxy detection.
- \`time.Now()\` on Linux vDSO is ~1 μs precise via \`clock_gettime(CLOCK_MONOTONIC)\`; μs is the honest resolution ceiling. Nanoseconds would imply precision the OS clock doesn't reliably provide.
- Comment refresh in \`cache.go\` / \`listener.go\` / \`clientHelloConnWrapper.go\` to keep the conceptual field names in sync.

## Breaking wire change — coordinate rollout
This is a header rename, not a dual-emit. Pronodes must ship the paired captcha-private PR (renaming \`tcpToChelloMs\`/\`chelloToHandshakeMs\` → \`tcpToChelloUs\`/\`chelloToHandshakeUs\` end-to-end, including the Mongo \`Session\` shape) **before** this chaddy image rolls to prod, otherwise the handshake-timing signal drops for the window in between.

Paired PR: to be linked once opened.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` — no new warnings (existing \`CaddyModule passes lock by value\` warning pre-exists on main)
- [ ] Deploy chaddy to bumblebee1, tail a session, confirm \`X-TLS-TCP-To-Chello-Us\` / \`X-TLS-Chello-To-Handshake-Us\` present and sub-ms values are non-zero for local hits
- [ ] Verify captcha-private consumer PR reads the new headers and writes \`*Us\` fields to \`captchastorage.sessions\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)